### PR TITLE
adding trigger info / better trigger matching to singlelepcalc (also adds soft lepton from b decays and leptons from taus to gen info stored in singlelepcalc)

### DIFF
--- a/interface/BaseEventSelector.h
+++ b/interface/BaseEventSelector.h
@@ -68,6 +68,10 @@ public:
     edm::Ptr<reco::PFMET> const & GetType1CorrMet() const { return mpType1CorrMet; }
     TLorentzVector const & GetCorrectedMet() const { return correctedMET_p4; }
     std::vector<unsigned int> const & GetSelectedTriggers() const { return mvSelTriggers; }
+    std::map<std::string, unsigned int> const & GetSelectedTriggersEl() const { return mvSelTriggersEl; }
+    std::map<std::string, unsigned int> const & GetSelectedTriggersMu() const { return mvSelTriggersMu; }
+    std::map<std::string, unsigned int> const & GetSelectedMCTriggersEl() const { return mvSelMCTriggersEl; }
+    std::map<std::string, unsigned int> const & GetSelectedMCTriggersMu() const { return mvSelMCTriggersMu; }
     std::vector<edm::Ptr<reco::Vertex>> const & GetSelectedPVs() const { return mvSelPVs; }
     double const & GetTestValue() const { return mTestValue; }
     void SetMc(bool isMc) { mbIsMc = isMc; }
@@ -104,6 +108,10 @@ protected:
     edm::Ptr<reco::PFMET> mpType1CorrMet;
     TLorentzVector correctedMET_p4;
     std::vector<unsigned int> mvSelTriggers;
+    std::map<std::string, unsigned int> mvSelTriggersEl;
+    std::map<std::string, unsigned int> mvSelTriggersMu;
+    std::map<std::string, unsigned int> mvSelMCTriggersEl;
+    std::map<std::string, unsigned int> mvSelMCTriggersMu;
     std::vector<edm::Ptr<reco::Vertex>> mvSelPVs;
     double mTestValue;
     

--- a/python/singleLepCalc_cfi.py
+++ b/python/singleLepCalc_cfi.py
@@ -2,6 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 singleLepCalc = cms.PSet(
                          dataType          = cms.string('All'),
+                         elTrigMatchFilters = cms.vstring('hltEle45CaloIdVTGsfTrkIdTGsfDphiFilter','hltEle95CaloIdVTGsfTrkIdTGsfDphiFilter'),
+                         muTrigMatchFilters = cms.vstring('hltL3fL1sMu16Eta2p1L1f0L2f16QL3Filtered40Q','hltL3fL1sMu16L1f0L2f16QL3Filtered40Q'),
                          isMc              = cms.bool(True),
                          pvCollection = cms.InputTag("offlineSlimmedPrimaryVertices"),
                          genParticles = cms.InputTag("prunedGenParticles"),

--- a/python/singleLepExample_cfg.py
+++ b/python/singleLepExample_cfg.py
@@ -62,8 +62,8 @@ process.event_selector = cms.PSet(
     trigger_cut  = cms.bool(True),
     dump_trigger = cms.bool(False),
     
-    mctrigger_path_el = cms.string('HLT_Ele32_eta2p1_WP85_Gsf_v1'),
-    mctrigger_path_mu = cms.string('HLT_IsoMu24_eta2p1_IterTrk02_v1'),
+    mctrigger_path_el = cms.vstring('HLT_Ele32_eta2p1_WP85_Gsf_v1'),
+    mctrigger_path_mu = cms.vstring('HLT_IsoMu24_eta2p1_IterTrk02_v1'),
     trigger_path_el = cms.vstring('HLT_Ele27_WP80_v8','HLT_Ele27_WP80_v9','HLT_Ele27_WP80_v10','HLT_Ele27_WP80_v11'),
     trigger_path_mu = cms.vstring('HLT_IsoMu24_eta2p1_v11','HLT_IsoMu24_eta2p1_v12','HLT_IsoMu24_eta2p1_v13','HLT_IsoMu24_eta2p1_v14','HLT_IsoMu24_eta2p1_v15'),
 

--- a/python/singleLepWprime_cfg.py
+++ b/python/singleLepWprime_cfg.py
@@ -20,6 +20,7 @@ process.ljmet.excluded_calculators = cms.vstring(
 	'LjetsTopoCalcNew',
 	'WprimeCalc',
 	'JetSubCalc',
+        'TpTpCalc',
 	'BTagSFCalc'
 	) 
 
@@ -57,10 +58,10 @@ process.event_selector = cms.PSet(
     trigger_cut  = cms.bool(True),
     dump_trigger = cms.bool(False),
     
-    mctrigger_path_el = cms.string('HLT_Ele32_eta2p1_WP85_Gsf_v1'),
-    mctrigger_path_mu = cms.string('HLT_IsoMu24_eta2p1_IterTrk02_v1'),
-    #mctrigger_path_el = cms.string('HLT_Ele45_CaloIdVT_GsfTrkIdT_PFJet200_PFJet50_v1'),
-    #mctrigger_path_mu = cms.string('HLT_Mu40_eta2p1_PFJet200_PFJet50_v1'),
+    mctrigger_path_el = cms.vstring('HLT_Ele32_eta2p1_WP85_Gsf_v1'),
+    mctrigger_path_mu = cms.vstring('HLT_IsoMu24_eta2p1_IterTrk02_v1'),
+    #mctrigger_path_el = cms.vstring('HLT_Ele45_CaloIdVT_GsfTrkIdT_PFJet200_PFJet50_v1'),
+    #mctrigger_path_mu = cms.vstring('HLT_Mu40_eta2p1_PFJet200_PFJet50_v1'),
     trigger_path_el = cms.vstring('HLT_Ele27_WP80_v8','HLT_Ele27_WP80_v9','HLT_Ele27_WP80_v10','HLT_Ele27_WP80_v11'),
     trigger_path_mu = cms.vstring('HLT_IsoMu24_eta2p1_v11','HLT_IsoMu24_eta2p1_v12','HLT_IsoMu24_eta2p1_v13','HLT_IsoMu24_eta2p1_v14','HLT_IsoMu24_eta2p1_v15'),
 
@@ -76,7 +77,7 @@ process.event_selector = cms.PSet(
 
     muon_cuts                = cms.bool(True),
     muon_selector            = cms.bool(False),
-    muon_minpt               = cms.double(35.0),
+    muon_minpt               = cms.double(25.0),
     muon_reliso              = cms.double(0.12),
     muon_maxeta              = cms.double(2.1),
     loose_muon_selector      = cms.bool(False),
@@ -87,7 +88,7 @@ process.event_selector = cms.PSet(
     min_muon                 = cms.int32(0),
 
     electron_cuts            = cms.bool(True),
-    electron_minpt           = cms.double(35.0),
+    electron_minpt           = cms.double(25.0),
     electron_maxeta          = cms.double(2.5),
     loose_electron_minpt     = cms.double(25.0),
     loose_electron_maxeta    = cms.double(2.5),

--- a/src/singleLepCalc.cc
+++ b/src/singleLepCalc.cc
@@ -40,6 +40,8 @@ private:
     edm::InputTag muonSrc_;
     bool                      isMc;
     std::string               dataType;
+    std::vector<std::string>  elTrigMatchFilters;
+    std::vector<std::string>  muTrigMatchFilters;
 //    edm::InputTag             rhoSrc_it;
     edm::InputTag             triggerSummary_;
     edm::InputTag             triggerCollection_;
@@ -76,6 +78,10 @@ int singleLepCalc::BeginJob()
 {
     if (mPset.exists("dataType"))     dataType = mPset.getParameter<std::string>("dataType");
     else                              dataType = "None"; 
+
+    if (mPset.exists("elTrigMatchFilters"))     elTrigMatchFilters = mPset.getParameter<std::vector<std::string>>("elTrigMatchFilters");
+
+    if (mPset.exists("muTrigMatchFilters"))     muTrigMatchFilters = mPset.getParameter<std::vector<std::string>>("muTrigMatchFilters");
 
     if (mPset.exists("rhoSrc")) rhoSrc_ = mPset.getParameter<edm::InputTag>("rhoSrc");
     else                        rhoSrc_ = edm::InputTag("fixedGridRhoAll");
@@ -123,7 +129,10 @@ int singleLepCalc::AnalyzeEvent(edm::EventBase const & event, BaseEventSelector 
     std::vector<edm::Ptr<pat::Muon> >           const & vSelMuons = selector->GetSelectedMuons();
     std::vector<edm::Ptr<pat::Electron> >       const & vSelElectrons = selector->GetSelectedElectrons();
     edm::Ptr<pat::MET>                          const & pMet = selector->GetMet();
-    std::vector<unsigned int>             const & vSelTriggers  = selector->GetSelectedTriggers();    
+    std::map<std::string, unsigned int>         const & mSelMCTriggersEl = selector->GetSelectedMCTriggersEl();
+    std::map<std::string, unsigned int>         const & mSelTriggersEl = selector->GetSelectedTriggersEl();
+    std::map<std::string, unsigned int>         const & mSelMCTriggersMu = selector->GetSelectedMCTriggersMu();
+    std::map<std::string, unsigned int>         const & mSelTriggersMu = selector->GetSelectedTriggersMu();
     // ----- Event kinematics -----
     int _nAllJets        = (int)vAllJets.size();
     int _nSelJets        = (int)vSelJets.size();
@@ -157,13 +166,32 @@ int singleLepCalc::AnalyzeEvent(edm::EventBase const & event, BaseEventSelector 
 
  
     // Trigger
-    int passE = 0;
-    int passM = 0;
-
-    if (vSelTriggers.size() == 2) {
-        passE = (int)vSelTriggers.at(0);
-        passM = (int)vSelTriggers.at(1);
+    std::vector<std::string> vsSelMCTriggersEl, vsSelTriggersEl, vsSelMCTriggersMu, vsSelTriggersMu;
+    std::vector<int> vuiSelMCTriggersEl, vuiSelTriggersEl, vuiSelMCTriggersMu, vuiSelTriggersMu;
+    for(std::map<std::string, unsigned int>::const_iterator j = mSelMCTriggersEl.begin(); j != mSelMCTriggersEl.end();j++) {
+        vsSelMCTriggersEl.push_back(j->first);
+        vuiSelMCTriggersEl.push_back((int)(j->second));
     }
+    for(std::map<std::string, unsigned int>::const_iterator j = mSelTriggersEl.begin(); j != mSelTriggersEl.end();j++) {
+        vsSelTriggersEl.push_back(j->first);
+        vuiSelTriggersEl.push_back((int)(j->second));
+    }
+    for(std::map<std::string, unsigned int>::const_iterator j = mSelMCTriggersMu.begin(); j != mSelMCTriggersMu.end();j++) {
+        vsSelMCTriggersMu.push_back(j->first);
+        vuiSelMCTriggersMu.push_back((int)(j->second));
+    }
+    for(std::map<std::string, unsigned int>::const_iterator j = mSelTriggersMu.begin(); j != mSelTriggersMu.end();j++) {
+        vsSelTriggersMu.push_back(j->first);
+        vuiSelTriggersMu.push_back((int)(j->second));
+    }
+    SetValue("vsSelMCTriggersEl", vsSelMCTriggersEl);
+    SetValue("vsSelTriggersEl", vsSelTriggersEl);
+    SetValue("vsSelMCTriggersMu", vsSelMCTriggersMu);
+    SetValue("vsSelTriggersMu", vsSelTriggersMu);
+    SetValue("vuiSelMCTriggersEl", vuiSelMCTriggersEl);
+    SetValue("vuiSelTriggersEl", vuiSelTriggersEl);
+    SetValue("vuiSelMCTriggersMu", vuiSelMCTriggersMu);
+    SetValue("vuiSelTriggersMu", vuiSelTriggersMu);
 
  
     std::vector< TLorentzVector > vGenLep;
@@ -562,25 +590,39 @@ int singleLepCalc::AnalyzeEvent(edm::EventBase const & event, BaseEventSelector 
 
     const edm::TriggerNames &names = event.triggerNames(*mhEdmTriggerResults);
 
-    int _electron_1_hltmatched =0;
-    int _muon_1_hltmatched =0;
+    std::vector<int> _electron_1_hltmatched;
+    std::vector<int> _muon_1_hltmatched;
 
     if (_nSelElectrons>0 || _nSelMuons>0) {
         for(pat::TriggerObjectStandAlone obj : *mhEdmTriggerObjectColl){       
             obj.unpackPathNames(names);
             for(unsigned h = 0; h < obj.filterLabels().size(); ++h){
-		if ( _nSelElectrons>0 ){
-                    if ( obj.filterLabels()[h]!="hltEle32WP85GsfTrackIsoFilter" ) continue;
-  	            if ( deltaR(obj.eta(),obj.phi(),elEta[0],elPhi[0]) < 0.5 ) _electron_1_hltmatched = 1;
+                for (unsigned int iel = 0; iel < elTrigMatchFilters.size(); iel++) {
+		    if ( _nSelElectrons>0 ){
+                        if ( obj.filterLabels()[h]!=elTrigMatchFilters[iel] ) {
+                            _electron_1_hltmatched.push_back(0);
+                            continue;
+                        }
+  	                if ( deltaR(obj.eta(),obj.phi(),elEta[0],elPhi[0]) < 0.5 ) _electron_1_hltmatched.push_back(1);
+                        else _electron_1_hltmatched.push_back(0);
+		    }
 		}
-		if ( _nSelMuons>0 ){
-                    if ( obj.filterLabels()[h]!="hltL3crIsoL1sMu20Eta2p1L1f0L2f20QL3f24QL3crIsoRhoFiltered0p15IterTrk02" ) continue;
-  	            if ( deltaR(obj.eta(),obj.phi(),muEta[0],muPhi[0]) < 0.5 ) _muon_1_hltmatched = 1;
+                for (unsigned int imu = 0; imu < muTrigMatchFilters.size(); imu++) {
+		    if ( _nSelMuons>0 ){
+                        if ( obj.filterLabels()[h]!=muTrigMatchFilters[imu] ) {
+                            _muon_1_hltmatched.push_back(0);
+                            continue;
+                        }
+  	                if ( deltaR(obj.eta(),obj.phi(),muEta[0],muPhi[0]) < 0.5 ) _muon_1_hltmatched.push_back(1);
+                        else _muon_1_hltmatched.push_back(0);
+		    }
 		}
             }
         }
     }
 
+    SetValue("electron_hltfilters",elTrigMatchFilters);
+    SetValue("muon_hltfilters",muTrigMatchFilters);
     SetValue("electron_1_hltmatched",_electron_1_hltmatched);
     SetValue("muon_1_hltmatched",_muon_1_hltmatched);
 
@@ -712,6 +754,20 @@ int singleLepCalc::AnalyzeEvent(edm::EventBase const & event, BaseEventSelector 
     std::vector <double> genJetPhi;
     std::vector <double> genJetEnergy;
 
+    //Tau Decay Lepton
+    double genTDLPt = -9999.;
+    double genTDLEta = -9999.;
+    double genTDLPhi = -9999.;
+    double genTDLEnergy = -9999.;
+    int genTDLID = 0;
+
+    //B Soft Leptons
+    std::vector <double> genBSLPt;
+    std::vector <double> genBSLEta;
+    std::vector <double> genBSLPhi;
+    std::vector <double> genBSLEnergy;
+    std::vector <int> genBSLID;
+
     if (isMc){
         edm::Handle<reco::GenParticleCollection> genParticles;
         event.getByLabel(genParticles_it, genParticles);
@@ -729,6 +785,31 @@ int singleLepCalc::AnalyzeEvent(edm::EventBase const & event, BaseEventSelector 
 	    //std::cout << i << "\t" << p.status() << "\t" << p.mass() << "\t" << p.pt() << "\t" << p.eta() << "\t" << p.phi() << "\t" << p.pdgId() << "\t";
 	    //if (!(!(p.mother()))) std::cout << p.mother()->pdgId();
 	    //std::cout << std::endl;
+
+	    if (p.status() == 1 && (abs(p.pdgId()) == 11 || abs(p.pdgId() == 13))){
+		if (!(!(p.mother()))) {
+		    if (!(p.mother()->status()==23 && (abs(p.mother()->pdgId()) == 11 || abs(p.mother()->pdgId()) == 13))) {
+                        if (!(!(p.mother()->mother())) && !(!(p.mother()->mother()->mother()))) {
+			    if (abs(p.mother()->mother()->pdgId()) == 15 && abs(p.mother()->mother()->pdgId()) == 15 && p.mother()->mother()->status() == 23) {
+                		genTDLPt     = p.pt();
+                		genTDLEta    = p.eta();
+                		genTDLPhi    = p.phi();
+                		genTDLEnergy = p.energy();
+                		genTDLID     = p.pdgId();
+                        	//std::cout << "TDL Pt = " << p.pt() << "\tTDL ID = " << p.pdgId() << std::endl;
+			    }
+			    else {
+                		genBSLPt     . push_back(p.pt());
+                		genBSLEta    . push_back(p.eta());
+                		genBSLPhi    . push_back(p.phi());
+                		genBSLEnergy . push_back(p.energy());
+                		genBSLID     . push_back(p.pdgId());
+                        	//std::cout << "BSL Pt = " << p.pt() << "\tBSL ID = " << p.pdgId() << std::endl;
+			    }
+			}
+		    }
+		}
+	    }
 
             //Find status 23 particles
             if (p.status() == 23){
@@ -835,6 +916,17 @@ int singleLepCalc::AnalyzeEvent(edm::EventBase const & event, BaseEventSelector 
     SetValue("genJetPhi"   , genJetPhi);
     SetValue("genJetEnergy", genJetEnergy);
 
+    SetValue("genBSLPt"    , genBSLPt);
+    SetValue("genBSLEta"   , genBSLEta);
+    SetValue("genBSLPhi"   , genBSLPhi);
+    SetValue("genBSLEnergy", genBSLEnergy);
+    SetValue("genBSLID"    , genBSLID);
+
+    SetValue("genTDLPt"    , genTDLPt);
+    SetValue("genTDLEta"   , genTDLEta);
+    SetValue("genTDLPhi"   , genTDLPhi);
+    SetValue("genTDLEnergy", genTDLEnergy);
+    SetValue("genTDLID"    , genTDLID);
 
     return 0;
 }


### PR DESCRIPTION
This change requires anyone using singleLepEventSelector to change their mctrigger_path_{el/mu} variables to type cms.vstring instead of cms.string

I changed the configs that are in this repository currently, but anyone with configs that are ignored by git will need to make the change themselves