### PR TITLE
MVA Electron Selector

### DIFF
--- a/interface/BaseEventSelector.h
+++ b/interface/BaseEventSelector.h
@@ -31,8 +31,17 @@
 #include "CondFormats/JetMETObjects/interface/JetCorrectionUncertainty.h"
 #include "CondFormats/JetMETObjects/interface/FactorizedJetCorrector.h"
 
+#include "RecoEgamma/EgammaTools/interface/ConversionTools.h"
+#include "TMath.h"
+#include "TMVA/Reader.h"
+#include "TMVA/MethodBDT.h"
+
 //#include "TROOT.h"
 //#include "TVector3.h"
+
+struct MVAElectronVars {
+    Float_t see, spp, OneMinusE1x5E5x5, R9, etawidth, phiwidth, HoE, PreShowerOverRaw, kfhits, kfchi2, gsfchi2, fbrem, convVtxFitProbability, EoP, eleEoPout, IoEmIoP, deta, dphi, detacalo, gsfhits, expectedMissingInnerHits, pt, isBarrel, isEndcap, SCeta, eClass, pfRelIso, expectedInnerHits, vtxconv, mcEventWeight, mcCBmatchingCategory;
+};
 
 class BaseEventSelector : public EventSelector {
     //
@@ -92,6 +101,7 @@ public:
     bool isJetTagged(const pat::Jet &jet, edm::EventBase const & event, bool applySF = true);
     TLorentzVector correctJet(const pat::Jet & jet, edm::EventBase const & event, bool doAK8Corr = false);
     TLorentzVector correctMet(const pat::MET & met, edm::EventBase const & event);
+    double mvaValue(const pat::Electron & electron, edm::EventBase const & event);
     
 protected:
     std::vector<edm::Ptr<pat::Jet>> mvAllJets;
@@ -121,6 +131,7 @@ protected:
     std::map<std::string, bool> mbPar;
     std::map<std::string, int> miPar;
     std::map<std::string, double> mdPar;
+    std::map<std::string, std::vector<double>> mvdPar;
     std::map<std::string, std::string> msPar;
     std::map<std::string, edm::InputTag> mtPar;
     std::map<std::string, std::vector<std::string>> mvsPar;
@@ -139,6 +150,10 @@ private:
     FactorizedJetCorrector *JetCorrector;
     FactorizedJetCorrector *JetCorrectorAK8;
     LjmetEventContent * mpEc;
+    MVAElectronVars allMVAVars;
+    TMVA::Reader tmpTMVAReader_EB;
+    TMVA::Reader tmpTMVAReader_EE;
+    
     
     /// Private init method to be called by LjmetFactory when registering the selector
     void init() { mLegend = "[" + mName + "]: "; std::cout << mLegend << "registering " << mName << std::endl; }

--- a/python/singleLepCalc_cfi.py
+++ b/python/singleLepCalc_cfi.py
@@ -16,4 +16,5 @@ singleLepCalc = cms.PSet(
                          keepPDGID    = cms.vuint32(1, 2, 3, 4, 5, 21, 11, 12, 13, 14, 15, 16),
                          keepMomPDGID = cms.vuint32(6, 24),
                          rhoSrc            = cms.InputTag("fixedGridRhoFastjetAll"),
+                         UseElMVA = cms.bool(True),
                          )

--- a/python/singleLepExample_cfg.py
+++ b/python/singleLepExample_cfg.py
@@ -103,6 +103,8 @@ process.event_selector = cms.PSet(
     min_electron             = cms.int32(0),
     loose_electron_minpt     = cms.double(20.0),
     loose_electron_maxeta    = cms.double(2.5),
+    tight_electron_mva_cuts   = cms.vdouble(0.913286,0.805013,0.358969),
+    loose_electron_mva_cuts   = cms.vdouble(0.913286,0.805013,0.358969),
     
     # more lepton cuts
     min_lepton               = cms.int32(1),
@@ -139,6 +141,7 @@ process.event_selector = cms.PSet(
     JEC_txtfile = cms.string(relBase+'/src/LJMet/Com/data/Summer15_50nsV5_DATA_UncertaintySources_AK4PFchs.txt'),
     doNewJEC                 = cms.bool(True),
     doLepJetCleaning         = cms.bool(True),
+    UseElMVA                 = cms.bool(True),
 
     MCL1JetPar               = cms.string(relBase+'/src/LJMet/Com/data/Summer15_50nsV5_MC_L1FastJet_AK4PFchs.txt'),
     MCL2JetPar               = cms.string(relBase+'/src/LJMet/Com/data/Summer15_50nsV5_MC_L2Relative_AK4PFchs.txt'),

--- a/src/singleLepCalc.cc
+++ b/src/singleLepCalc.cc
@@ -55,6 +55,7 @@ private:
     std::vector<unsigned int> keepMomPDGID;
     bool keepFullMChistory;
     bool cleanGenJets;
+    bool UseElMVA;
 
     double rhoIso;
 
@@ -122,6 +123,9 @@ int singleLepCalc::BeginJob()
  
     if (mPset.exists("cleanGenJets")) cleanGenJets = mPset.getParameter<bool>("cleanGenJets");
     else                              cleanGenJets = false;
+
+    if (mPset.exists("UseElMVA")) UseElMVA = mPset.getParameter<bool>("UseElMVA");
+    else                          UseElMVA = false;
 
     return 0;
 }
@@ -412,7 +416,7 @@ int singleLepCalc::AnalyzeEvent(edm::EventBase const & event, BaseEventSelector 
     std::vector <int>    elMHits;
     std::vector <int>    elVtxFitConv;    
 
-    std::vector <bool> elTight;
+    std::vector <double> elMVAValue;
  
     //Extra info about isolation
     std::vector <double> elChIso;
@@ -512,14 +516,7 @@ int singleLepCalc::AnalyzeEvent(edm::EventBase const & event, BaseEventSelector 
             elVtxFitConv.push_back((*iel)->passConversionVeto());
             elNotConversion.push_back((*iel)->passConversionVeto());
 
-            bool pass = false;
-            if ((*iel)->isEB()) {
-                if (( fabs((*iel)->deltaEtaSuperClusterTrackAtVtx()) < 0.0095 ) && (fabs((*iel)->deltaPhiSuperClusterTrackAtVtx()) < 0.0291) && ((*iel)->full5x5_sigmaIetaIeta() < 0.0101) && ((*iel)->hadronicOverEm() < 0.0372) && (fabs((*iel)->gsfTrack()->dxy(goodPVs.at(0).position())) < 0.0144) && (fabs((*iel)->gsfTrack()->dz(goodPVs.at(0).position())) < 0.323) && (fabs(1.0/(*iel)->ecalEnergy() + (*iel)->eSuperClusterOverP()/(*iel)->ecalEnergy()) < 0.0174) && (relIso < 0.0468) && ((*iel)->gsfTrack()->hitPattern().numberOfLostTrackerHits(reco::HitPattern::MISSING_INNER_HITS) <= 2)) pass = true;
-            }
-            else {
-                if (( fabs((*iel)->deltaEtaSuperClusterTrackAtVtx()) < 0.00762 ) && (fabs((*iel)->deltaPhiSuperClusterTrackAtVtx()) < 0.0439) && ((*iel)->full5x5_sigmaIetaIeta() < 0.0287) && ((*iel)->hadronicOverEm() < 0.0544) && (fabs((*iel)->gsfTrack()->dxy(goodPVs.at(0).position())) < 0.0377) && (fabs((*iel)->gsfTrack()->dz(goodPVs.at(0).position())) < 0.571) && (fabs(1.0/(*iel)->ecalEnergy() + (*iel)->eSuperClusterOverP()/(*iel)->ecalEnergy()) < 0.01) && (relIso < 0.0759) && ((*iel)->gsfTrack()->hitPattern().numberOfLostTrackerHits(reco::HitPattern::MISSING_INNER_HITS) <= 1)) pass = true;
-            }
-            elTight.push_back(pass);
+            if (UseElMVA) elMVAValue.push_back( selector->mvaValue(iel->operator*(),event) );
 
             if(isMc && keepFullMChistory){
                 //cout << "start\n";
@@ -588,7 +585,7 @@ int singleLepCalc::AnalyzeEvent(edm::EventBase const & event, BaseEventSelector 
     SetValue("elMHits", elMHits);
     SetValue("elVtxFitConv", elVtxFitConv);
 
-    SetValue("elTight", elTight);
+    SetValue("elMVAValue", elMVAValue);
 
     //Extra info about isolation
     SetValue("elChIso" , elChIso);

--- a/src/singleLepEventSelector.cc
+++ b/src/singleLepEventSelector.cc
@@ -292,6 +292,7 @@ void singleLepEventSelector::BeginJob( std::map<std::string, edm::ParameterSet c
         msPar["JEC_txtfile"]              = par[_key].getParameter<std::string>  ("JEC_txtfile");
         mbPar["doNewJEC"]                 = par[_key].getParameter<bool>         ("doNewJEC");
         mbPar["doLepJetCleaning"]         = par[_key].getParameter<bool>         ("doLepJetCleaning");
+        mbPar["UseElMVA"]                 = par[_key].getParameter<bool>         ("UseElMVA");
       
 
         std::cout << mLegend << "config parameters loaded..."
@@ -753,10 +754,11 @@ bool singleLepEventSelector::operator()( edm::EventBase const & event, pat::strb
                     else break;
 
                     if ( mbPar["UseElMVA"] ) {
-                        if ( fabs(_iel->superCluster()->eta())<=0.8 && mvaValue( *_iel, event) > mvdPar["tight_electron_mva_cuts"].at(0) ) {}
-                        else if ( fabs(_iel->superCluster()->eta())<=1.479 && fabs(_iel->superCluster()->eta())>0.8 && mvaValue( *_iel, event) > mvdPar["tight_electron_mva_cuts"].at(1) ) {}
-                        else if ( fabs(_iel->superCluster()->eta())>1.479 && mvaValue( *_iel, event) > mvdPar["tight_electron_mva_cuts"].at(2) ) {}
-                        else break;
+                        bool mvapass = false;
+                        if ( fabs(_iel->superCluster()->eta())<=0.8) mvapass = mvaValue( *_iel, event) > mvdPar["tight_electron_mva_cuts"].at(0);
+                        else if ( fabs(_iel->superCluster()->eta())<=1.479 && fabs(_iel->superCluster()->eta())>0.8) mvapass = mvaValue( *_iel, event) > mvdPar["tight_electron_mva_cuts"].at(2);
+                        else mvapass = mvaValue( *_iel, event) > mvdPar["tight_electron_mva_cuts"].at(2);
+                        if (!mvapass) break;
                     }
                     else {
                         if ( (*electronSel_)( *_iel, event, retElectron ) ){ }
@@ -791,10 +793,11 @@ bool singleLepEventSelector::operator()( edm::EventBase const & event, pat::strb
                         else break;
 
                         if ( mbPar["UseElMVA"] ) {
-                            if ( fabs(_iel->superCluster()->eta())<=0.8 && mvaValue( *_iel, event) > mvdPar["loose_electron_mva_cuts"].at(0) ) {}
-                            else if ( fabs(_iel->superCluster()->eta())<=1.479 && fabs(_iel->superCluster()->eta())>0.8 && mvaValue( *_iel, event) > mvdPar["loose_electron_mva_cuts"].at(1) ) {}
-                            else if ( fabs(_iel->superCluster()->eta())>1.479 && mvaValue( *_iel, event) > mvdPar["loose_electron_mva_cuts"].at(2) ) {}
-                            else break;
+                            bool mvapass = false;
+                            if ( fabs(_iel->superCluster()->eta())<=0.8) mvapass = mvaValue( *_iel, event) > mvdPar["tight_electron_mva_cuts"].at(0);
+                            else if ( fabs(_iel->superCluster()->eta())<=1.479 && fabs(_iel->superCluster()->eta())>0.8) mvapass = mvaValue( *_iel, event) > mvdPar["tight_electron_mva_cuts"].at(2);
+                            else if ( fabs(_iel->superCluster()->eta())>1.479) mvapass = mvaValue( *_iel, event) > mvdPar["tight_electron_mva_cuts"].at(2);
+                            if (!mvapass) break;
                         }
                         else {
                             if ( (*looseElectronSel_)( *_iel, event, retLooseElectron ) ){ }

--- a/src/singleLepEventSelector.cc
+++ b/src/singleLepEventSelector.cc
@@ -251,12 +251,16 @@ void singleLepEventSelector::BeginJob( std::map<std::string, edm::ParameterSet c
         mdPar["loose_muon_maxeta"]         = par[_key].getParameter<double>       ("loose_muon_maxeta");
         miPar["min_muon"]                  = par[_key].getParameter<int>          ("min_muon");
 
-        mbPar["electron_cuts"]                 = par[_key].getParameter<bool>         ("electron_cuts");
-        mdPar["electron_minpt"]                = par[_key].getParameter<double>       ("electron_minpt");
-        mdPar["electron_maxeta"]               = par[_key].getParameter<double>       ("electron_maxeta");
-        mdPar["loose_electron_minpt"]          = par[_key].getParameter<double>       ("loose_electron_minpt");
-        mdPar["loose_electron_maxeta"]         = par[_key].getParameter<double>       ("loose_electron_maxeta");
-        miPar["min_electron"]                  = par[_key].getParameter<int>          ("min_electron");
+        mbPar["electron_cuts"]             = par[_key].getParameter<bool>         ("electron_cuts");
+        mdPar["electron_minpt"]            = par[_key].getParameter<double>       ("electron_minpt");
+        mdPar["electron_maxeta"]           = par[_key].getParameter<double>       ("electron_maxeta");
+        mdPar["loose_electron_minpt"]      = par[_key].getParameter<double>       ("loose_electron_minpt");
+        mdPar["loose_electron_maxeta"]     = par[_key].getParameter<double>       ("loose_electron_maxeta");
+        miPar["min_electron"]              = par[_key].getParameter<int>          ("min_electron");
+        if (par[_key].exists("UseElMVA")) {
+            mvdPar["tight_electron_mva_cuts"] = par[_key].getParameter<std::vector<double>> ("tight_electron_mva_cuts");
+            mvdPar["loose_electron_mva_cuts"] = par[_key].getParameter<std::vector<double>> ("tight_electron_mva_cuts");
+        }
 
         miPar["min_lepton"]               = par[_key].getParameter<int>          ("min_lepton");
         miPar["max_lepton"]               = par[_key].getParameter<int>          ("max_lepton");
@@ -748,8 +752,16 @@ bool singleLepEventSelector::operator()( edm::EventBase const & event, pat::strb
                     if (!((*_iel).isEBEEGap())){ }
                     else break;
 
-                    if ( (*electronSel_)( *_iel, event, retElectron ) ){ }
-                    else break; // fail
+                    if ( mbPar["UseElMVA"] ) {
+                        if ( fabs(_iel->superCluster()->eta())<=0.8 && mvaValue( *_iel, event) > mvdPar["tight_electron_mva_cuts"].at(0) ) {}
+                        else if ( fabs(_iel->superCluster()->eta())<=1.479 && fabs(_iel->superCluster()->eta())>0.8 && mvaValue( *_iel, event) > mvdPar["tight_electron_mva_cuts"].at(1) ) {}
+                        else if ( fabs(_iel->superCluster()->eta())>1.479 && mvaValue( *_iel, event) > mvdPar["tight_electron_mva_cuts"].at(2) ) {}
+                        else break;
+                    }
+                    else {
+                        if ( (*electronSel_)( *_iel, event, retElectron ) ){ }
+                        else break; // fail
+                    }
 
                     pass = true; // success
                     break;
@@ -778,8 +790,16 @@ bool singleLepEventSelector::operator()( edm::EventBase const & event, pat::strb
                         if (!((*_iel).isEBEEGap())){ }
                         else break;
 
-                        if ( (*looseElectronSel_)( *_iel, event, retLooseElectron ) ){ }
-                        else break; // fail
+                        if ( mbPar["UseElMVA"] ) {
+                            if ( fabs(_iel->superCluster()->eta())<=0.8 && mvaValue( *_iel, event) > mvdPar["loose_electron_mva_cuts"].at(0) ) {}
+                            else if ( fabs(_iel->superCluster()->eta())<=1.479 && fabs(_iel->superCluster()->eta())>0.8 && mvaValue( *_iel, event) > mvdPar["loose_electron_mva_cuts"].at(1) ) {}
+                            else if ( fabs(_iel->superCluster()->eta())>1.479 && mvaValue( *_iel, event) > mvdPar["loose_electron_mva_cuts"].at(2) ) {}
+                            else break;
+                        }
+                        else {
+                            if ( (*looseElectronSel_)( *_iel, event, retLooseElectron ) ){ }
+                            else break; // fail
+                        }
 
                         pass_loose = true; // success
                         break;

--- a/tools/LumiReWeighting.h
+++ b/tools/LumiReWeighting.h
@@ -28,7 +28,7 @@ public:
 	// normalize both histograms first
 	Data_distr_->Scale( 1.0/ Data_distr_->Integral() );
 	MC_distr_->Scale( 1.0/ MC_distr_->Integral() );
-	std::cout << Data_distr_->Integral()<<" "<<MC_distr_->Integral()<<std::endl;
+	//std::cout << Data_distr_->Integral()<<" "<<MC_distr_->Integral()<<std::endl;
 
 	weights_ =  static_cast<TH1*>(Data_distr_->Clone()) ;
 
@@ -37,17 +37,17 @@ public:
 	TH1* den = dynamic_cast<TH1*>(MC_distr_->Clone());
 
 	//den->Scale(1.0/ den->Integral());
-	std::cout << weights_->Integral()<<" "<<den->Integral()<<std::endl;
+	//std::cout << weights_->Integral()<<" "<<den->Integral()<<std::endl;
 
 	weights_->Divide( den );  // so now the average weight should be 1.0
-	std::cout << weights_->Integral()<<" "<<den->Integral()<<std::endl;
+	//std::cout << weights_->Integral()<<" "<<den->Integral()<<std::endl;
 
-	std::cout << " Lumi/Pileup Reweighting: Computed Weights per In-Time Nint " << std::endl;
+	//std::cout << " Lumi/Pileup Reweighting: Computed Weights per In-Time Nint " << std::endl;
 
 	int NBins = weights_->GetNbinsX();
 
 	for(int ibin = 1; ibin<NBins+1; ++ibin){
-	  std::cout << "   " << ibin-1 << " " << weights_->GetBinContent(ibin) << std::endl;
+	  //std::cout << "   " << ibin-1 << " " << weights_->GetBinContent(ibin) << std::endl;
 	}
 };
 


### PR DESCRIPTION
I have added the MVA electron selector to BaseEventSelector which enables the BDTs to be booked only once per ljmet job, meaning using the mva electron ID can run in finite time. I also added the mva value to singleLepCalc, but the procedure should be easily adaptable for other calculators
