### PR TITLE
New correctJet method & JEC in JetSubCalc

### DIFF
--- a/interface/BaseEventSelector.h
+++ b/interface/BaseEventSelector.h
@@ -127,8 +127,6 @@ protected:
     std::map<std::string, unsigned int> mvSelTriggersMu;
     std::map<std::string, unsigned int> mvSelMCTriggersEl;
     std::map<std::string, unsigned int> mvSelMCTriggersMu;
-    std::map<std::string, int> mvSelPrescalesEl;
-    std::map<std::string, int> mvSelPrescalesMu;
     std::vector<edm::Ptr<reco::Vertex>> mvSelPVs;
     double mTestValue;
     

--- a/interface/BaseEventSelector.h
+++ b/interface/BaseEventSelector.h
@@ -100,6 +100,7 @@ public:
     
     bool isJetTagged(const pat::Jet &jet, edm::EventBase const & event, bool applySF = true);
     TLorentzVector correctJet(const pat::Jet & jet, edm::EventBase const & event, bool doAK8Corr = false);
+    pat::Jet correctJetReturnPatJet(const pat::Jet & jet, edm::EventBase const & event, bool doAK8Corr = false);
     TLorentzVector correctMet(const pat::MET & met, edm::EventBase const & event);
     TLorentzVector correctMet(const pat::MET & met, edm::EventBase const & event, std::vector<pat::Jet> jets);
     TLorentzVector correctMet(const pat::MET & met, edm::EventBase const & event, std::vector<edm::Ptr<pat::Jet> > jets);
@@ -126,6 +127,8 @@ protected:
     std::map<std::string, unsigned int> mvSelTriggersMu;
     std::map<std::string, unsigned int> mvSelMCTriggersEl;
     std::map<std::string, unsigned int> mvSelMCTriggersMu;
+    std::map<std::string, int> mvSelPrescalesEl;
+    std::map<std::string, int> mvSelPrescalesMu;
     std::vector<edm::Ptr<reco::Vertex>> mvSelPVs;
     double mTestValue;
     

--- a/python/JetSubCalc_cfi.py
+++ b/python/JetSubCalc_cfi.py
@@ -18,6 +18,8 @@ JetSubCalc = cms.PSet(
                       tagInfo            = cms.string("caTop"),
                       kappa              = cms.double(0.5),
                       useHTT             = cms.bool(False),
+                      killHF             = cms.bool(False),
+                      doNewJEC           = cms.bool(False),
                       selectedJetsCA15Coll = cms.InputTag("selectedPatJetsCA15PFCHSNoHF")
                       )
 

--- a/src/BaseEventSelector.cc
+++ b/src/BaseEventSelector.cc
@@ -467,29 +467,48 @@ TLorentzVector BaseEventSelector::correctJet(const pat::Jet & jet, edm::EventBas
     }
     else if (!mbPar["isMc"]) {
       
-        if (mbPar["doNewJEC"]) {
-	
-            // We need to undo the default corrections and then apply the new ones
+      if (mbPar["doNewJEC"]) {
 
-            double pt_raw = jet.correctedJet(0).pt();
-            JetCorrector->setJetEta(jet.eta());
-            JetCorrector->setJetPt(pt_raw);
-            JetCorrector->setJetA(jet.jetArea());
-            JetCorrector->setRho(rho); 
+	double pt_raw = jet.correctedJet(0).pt();	
+	// We need to undo the default corrections and then apply the new ones
 	
-	    try{
-	        correction = JetCorrector->getCorrection();
-	    }
-	    catch(...){
-	        std::cout << mLegend << "WARNING! Exception thrown by JetCorrectionUncertainty!" << std::endl;
-	        std::cout << mLegend << "WARNING! Possibly, trying to correct a jet/MET outside correction range." << std::endl;
-	        std::cout << mLegend << "WARNING! Jet/MET will remain uncorrected." << std::endl;
-	    }
+	if (doAK8Corr){
+	  JetCorrectorAK8->setJetEta(jet.eta());
+	  JetCorrectorAK8->setJetPt(pt_raw);
+	  JetCorrectorAK8->setJetA(jet.jetArea());
+	  JetCorrectorAK8->setRho(rho); 
 	  
-            correctedJet.scaleEnergy(correction);
-            pt = correctedJet.pt();
-
-        }
+	  try{
+	    correction = JetCorrectorAK8->getCorrection();
+	  }
+	  catch(...){
+	    std::cout << mLegend << "WARNING! Exception thrown by JetCorrectionUncertainty!" << std::endl;
+	    std::cout << mLegend << "WARNING! Possibly, trying to correct a jet/MET outside correction range." << std::endl;
+	    std::cout << mLegend << "WARNING! Jet/MET will remain uncorrected." << std::endl;
+	  }
+	}
+	
+	else{
+	  double pt_raw = jet.correctedJet(0).pt();
+	  JetCorrector->setJetEta(jet.eta());
+	  JetCorrector->setJetPt(pt_raw);
+	  JetCorrector->setJetA(jet.jetArea());
+	  JetCorrector->setRho(rho); 
+	  
+	  try{
+	    correction = JetCorrector->getCorrection();
+	  }
+	  catch(...){
+	    std::cout << mLegend << "WARNING! Exception thrown by JetCorrectionUncertainty!" << std::endl;
+	    std::cout << mLegend << "WARNING! Possibly, trying to correct a jet/MET outside correction range." << std::endl;
+	    std::cout << mLegend << "WARNING! Jet/MET will remain uncorrected." << std::endl;
+	  }
+	  
+	}
+	correctedJet.scaleEnergy(correction);
+	pt = correctedJet.pt();
+	
+      }
     }
 
     TLorentzVector jetP4;
@@ -510,6 +529,189 @@ TLorentzVector BaseEventSelector::correctJet(const pat::Jet & jet, edm::EventBas
 
 
     return jetP4;
+}
+
+pat::Jet BaseEventSelector::correctJetReturnPatJet(const pat::Jet & jet, edm::EventBase const & event, bool doAK8Corr)
+{
+
+  // JES and JES systematics
+    pat::Jet correctedJet;
+    if (mbPar["doNewJEC"])
+        correctedJet = jet.correctedJet(0);                 //copy original jet
+    else
+        correctedJet = jet;                                 //copy default corrected jet
+
+    double ptscale = 1.0;
+    double unc = 1.0;
+    double pt = correctedJet.pt();
+    double correction = 1.0;
+
+    edm::Handle<double> rhoHandle;
+    edm::InputTag rhoSrc_("fixedGridRhoAll", "");
+    event.getByLabel(rhoSrc_, rhoHandle);
+    double rho = std::max(*(rhoHandle.product()), 0.0);
+
+    if ( mbPar["isMc"] ){ 
+
+    	if (mbPar["doNewJEC"]) {
+      	    // We need to undo the default corrections and then apply the new ones
+ 
+      	    double pt_raw = jet.correctedJet(0).pt();
+
+	    if (doAK8Corr){
+                JetCorrectorAK8->setJetEta(jet.eta());
+          	JetCorrectorAK8->setJetPt(pt_raw);
+                JetCorrectorAK8->setJetA(jet.jetArea());
+          	JetCorrectorAK8->setRho(rho); 
+    
+                try{
+    		    correction = JetCorrectorAK8->getCorrection();
+                }
+          	catch(...){
+    		    std::cout << mLegend << "WARNING! Exception thrown by JetCorrectionUncertainty!" << std::endl;
+    		    std::cout << mLegend << "WARNING! Possibly, trying to correct a jet/MET outside correction range." << std::endl;
+    		    std::cout << mLegend << "WARNING! Jet/MET will remain uncorrected." << std::endl;
+                }
+	    }
+
+	    else{
+                JetCorrector->setJetEta(jet.eta());
+          	JetCorrector->setJetPt(pt_raw);
+                JetCorrector->setJetA(jet.jetArea());
+          	JetCorrector->setRho(rho); 
+    
+                try{
+    		    correction = JetCorrector->getCorrection();
+                }
+          	catch(...){
+    		    std::cout << mLegend << "WARNING! Exception thrown by JetCorrectionUncertainty!" << std::endl;
+    		    std::cout << mLegend << "WARNING! Possibly, trying to correct a jet/MET outside correction range." << std::endl;
+    		    std::cout << mLegend << "WARNING! Jet/MET will remain uncorrected." << std::endl;
+                }
+	    }
+      
+            correctedJet.scaleEnergy(correction);
+            pt = correctedJet.pt();
+
+        }
+        double factor = 0.0; // For Nominal Case
+        double theAbsJetEta = fabs(jet.eta());
+        
+        if ( theAbsJetEta < 0.5 ) {
+            factor = .052;
+            if (mbPar["JERup"]) factor = 0.115;
+            if (mbPar["JERdown"]) factor = -0.011;
+        }
+        else if ( theAbsJetEta < 1.1) {
+            factor = 0.057;
+            if (mbPar["JERup"]) factor = 0.114;
+            if (mbPar["JERdown"]) factor = 0.0;
+        }
+        else if ( theAbsJetEta < 1.7) {
+            factor = 0.096;
+            if (mbPar["JERup"]) factor = 0.161;
+            if (mbPar["JERdown"]) factor = 0.031;
+        }
+        else if ( theAbsJetEta < 2.3) {
+            factor = 0.134;
+            if (mbPar["JERup"]) factor = 0.228;
+            if (mbPar["JERdown"]) factor = 0.040;
+            
+        }
+        else if (theAbsJetEta < 5.0) {
+            factor = 0.288;
+            if (mbPar["JERup"]) factor = 0.488;
+            if (mbPar["JERdown"]) factor = 0.088;
+        }
+
+        const reco::GenJet * genJet = jet.genJet();
+    	if (genJet && genJet->pt()>15. && (fabs(genJet->pt()/pt-1)<0.5)){
+      	    double gen_pt = genJet->pt();
+      	    double reco_pt = pt;
+            double deltapt = (reco_pt - gen_pt) * factor;
+            ptscale = max(0.0, (reco_pt + deltapt) / reco_pt);
+        }
+
+        if ( mbPar["JECup"] || mbPar["JECdown"]) {
+            jecUnc->setJetEta(jet.eta());
+            jecUnc->setJetPt(pt*ptscale);
+
+        if (mbPar["JECup"]) { 
+	    try{
+                unc = jecUnc->getUncertainty(true);
+	    }
+	    catch(...){ // catch all exceptions. Jet Uncertainty tool throws when binning out of range
+	        std::cout << mLegend << "WARNING! Exception thrown by JetCorrectionUncertainty!" << std::endl;
+                std::cout << mLegend << "WARNING! Possibly, trying to correct a jet/MET outside correction range." << std::endl;
+	        std::cout << mLegend << "WARNING! Jet/MET will remain uncorrected." << std::endl;
+	        unc = 0.0;
+	    }
+            unc = 1 + unc; 
+        }
+        else { 
+	    try{
+                unc = jecUnc->getUncertainty(false);
+	    }
+	    catch(...){
+	        std::cout << mLegend << "WARNING! Exception thrown by JetCorrectionUncertainty!" << std::endl;
+	        std::cout << mLegend << "WARNING! Possibly, trying to correct a jet/MET outside correction range." << std::endl;
+	        std::cout << mLegend << "WARNING! Jet/MET will remain uncorrected." << std::endl;
+	        unc = 0.0;
+	    }
+            unc = 1 - unc; 
+        }
+
+        if (pt*ptscale < 10.0 && mbPar["JECup"]) unc = 2.0;
+        if (pt*ptscale < 10.0 && mbPar["JECdown"]) unc = 0.01;
+
+        }
+    }
+    else if (!mbPar["isMc"]) {
+      
+        if (mbPar["doNewJEC"]) {
+
+	  double pt_raw = jet.correctedJet(0).pt();	
+            // We need to undo the default corrections and then apply the new ones
+
+	  if (doAK8Corr){
+	    JetCorrectorAK8->setJetEta(jet.eta());
+	    JetCorrectorAK8->setJetPt(pt_raw);
+	    JetCorrectorAK8->setJetA(jet.jetArea());
+	    JetCorrectorAK8->setRho(rho); 
+	    
+	    try{
+	      correction = JetCorrectorAK8->getCorrection();
+	    }
+	    catch(...){
+	      std::cout << mLegend << "WARNING! Exception thrown by JetCorrectionUncertainty!" << std::endl;
+	      std::cout << mLegend << "WARNING! Possibly, trying to correct a jet/MET outside correction range." << std::endl;
+	      std::cout << mLegend << "WARNING! Jet/MET will remain uncorrected." << std::endl;
+	    }
+	  }
+
+	  else{
+	    double pt_raw = jet.correctedJet(0).pt();
+            JetCorrector->setJetEta(jet.eta());
+            JetCorrector->setJetPt(pt_raw);
+            JetCorrector->setJetA(jet.jetArea());
+            JetCorrector->setRho(rho); 
+	    
+	    try{
+	      correction = JetCorrector->getCorrection();
+	    }
+	    catch(...){
+	      std::cout << mLegend << "WARNING! Exception thrown by JetCorrectionUncertainty!" << std::endl;
+	      std::cout << mLegend << "WARNING! Possibly, trying to correct a jet/MET outside correction range." << std::endl;
+	      std::cout << mLegend << "WARNING! Jet/MET will remain uncorrected." << std::endl;
+	    }
+	  }
+	  correctedJet.scaleEnergy(correction);
+	  pt = correctedJet.pt();
+
+        }
+    }
+
+    return correctedJet;
 }
 
 bool BaseEventSelector::isJetTagged(const pat::Jet & jet, edm::EventBase const & event, bool applySF)


### PR DESCRIPTION
Added "correctJetReturnPatJet" to get the full pat::Jet post-JEC corrections. Used now in JetSubCalc with configurable option.

Added AK8 JEC for data, previously it wasn't checking the bool. 
