### PR TITLE
New cleaned+corrected jet vec; 76X b tagging

### DIFF
--- a/BuildFile.xml
+++ b/BuildFile.xml
@@ -1,5 +1,6 @@
 <use name="FWCore/PluginManager"/>
 <use name="DataFormats/Math"/>
+<use name="DataFormats/Candidate"/>
 <use name="DataFormats/Common"/>
 <use name="DataFormats/JetReco"/>
 <use name="DataFormats/MuonReco"/>

--- a/interface/BaseEventSelector.h
+++ b/interface/BaseEventSelector.h
@@ -84,6 +84,7 @@ public:
     std::vector<edm::Ptr<pat::Jet>> const & GetAllJets() const { return mvAllJets; }
     std::vector<edm::Ptr<pat::Jet>> const & GetSelectedJets() const { return mvSelJets; }
     std::vector<pat::Jet> const & GetSelectedCleanedJets() const { return mvSelJetsCleaned; }
+    std::vector<pat::Jet> const & GetSelectedCorrJets() const { return mvSelCorrJets; }
     std::vector<edm::Ptr<pat::Jet>> const & GetLooseJets() const { return mvSelJets; }
     std::vector<edm::Ptr<pat::Jet>> const & GetSelectedBtagJets() const { return mvSelBtagJets; }
     std::vector<std::pair<TLorentzVector, bool>> const & GetCorrJetsWithBTags() const { return mvCorrJetsWithBTags; }
@@ -117,7 +118,7 @@ public:
     void SetCorrectedMet(TLorentzVector & met) { correctedMET_p4 = met; }
     void SetCorrJetsWithBTags(std::vector<std::pair<TLorentzVector, bool>> & jets) { mvCorrJetsWithBTags = jets; }
     
-    bool isJetTagged(const pat::Jet &jet, edm::EventBase const & event, bool applySF = true);
+    bool isJetTagged(const pat::Jet &jet, edm::EventBase const & event, bool applySF = true, int shiftflag = 0);
     TLorentzVector correctJetForMet(const pat::Jet & jet, edm::EventBase const & event);
     TLorentzVector correctJet(const pat::Jet & jet, edm::EventBase const & event, bool doAK8Corr = false, bool forceCorr = false);
     pat::Jet correctJetReturnPatJet(const pat::Jet & jet, edm::EventBase const & event, bool doAK8Corr = false, bool forceCorr = false);
@@ -130,6 +131,7 @@ protected:
     std::vector<edm::Ptr<pat::Jet>> mvAllJets;
     std::vector<edm::Ptr<pat::Jet>> mvSelJets;
     std::vector<pat::Jet> mvSelJetsCleaned;
+    std::vector<pat::Jet> mvSelCorrJets;
     std::vector<edm::Ptr<pat::Jet>> mvLooseJets;
     std::vector<std::pair<TLorentzVector, bool>> mvCorrJetsWithBTags;
     std::vector<edm::Ptr<pat::Jet>> mvSelBtagJets;

--- a/interface/BtagHardcodedConditions.h
+++ b/interface/BtagHardcodedConditions.h
@@ -54,6 +54,7 @@ private:
     double GetBtagSFUncertainty2015(double pt, double eta, std::string tagger="CSVM");
     double GetMistagSF2011(double pt, double eta, std::string tagger, std::string meanminmax);
     double GetMistagSF2012(double pt, double eta, std::string tagger, std::string meanminmax);
+    double GetMistagSF2015(double pt, double eta, std::string tagger, std::string meanminmax);
     inline void fillArray(float* a, float* b, int n) {
         for (int i=0;i<n;++i) a[i] = b[i];
     }

--- a/src/BTagSFUtil.cc
+++ b/src/BTagSFUtil.cc
@@ -65,7 +65,7 @@ void BTagSFUtil::modifyBTagsWithSF(bool& isBTagged, int pdgIdPart,
     newBTag = applySF(isBTagged, Btag_SF, bctag_eff);
 
   // light quarks:
-  } else if( abs( pdgIdPart )>0 ) { //in data it is 0 (save computing time)
+  } else { // need 0's with hadronFlavor
 
     newBTag = applySF(isBTagged, Bmistag_SF, Bmistag_eff);
     

--- a/src/BtagHardcodedConditions.cc
+++ b/src/BtagHardcodedConditions.cc
@@ -53,10 +53,10 @@ BtagHardcodedConditions::BtagHardcodedConditions() {
     float ptminT12[16] = {20, 30, 40, 50, 60, 70, 80, 100, 120, 160, 210, 260, 320, 400, 500, 600};
     for (int i=0;i<16;++i) ptRange12.push_back(ptminT12[i]);
 
-    // 2015 scale factors from csv file in https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation74X50ns
-    float SFb_CSVL_temp15[7]  = {0.022327613085508347, 0.015330483205616474, 0.024493992328643799, 0.020933238789439201, 0.029219608753919601, 0.039571482688188553, 0.047329759448766708};
-    float SFb_CSVM_temp15[7]  = {0.031647235155105591, 0.021615911275148392, 0.032769639045000076, 0.024189794436097145, 0.043655604124069214, 0.060466367751359940, 0.064764265418052673};
-    float SFb_CSVT_temp15[7]  = {0.031852148473262787, 0.023946098983287811, 0.038635428994894028, 0.031439229846000671, 0.049481656402349472, 0.074025325477123260, 0.074882696777582169};
+    // 2015 scale factors from csv file in https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation76X
+    float SFb_CSVL_temp15[7]  = {0.011052364483475685,0.016565520316362381,0.015128300525248051,0.018585314974188805,0.019014466553926468,0.018456572666764259,0.040404733270406723};
+    float SFb_CSVM_temp15[7]  = {0.018076473847031593,0.024799736216664314,0.024073265492916107,0.020040607079863548,0.016540588811039925,0.025977084413170815,0.027120551094412804};
+    float SFb_CSVT_temp15[7]  = {0.019803794100880623,0.026958625763654709,0.024285079911351204,0.028512096032500267,0.029808893799781799,0.026503190398216248,0.042264193296432495};
     fillArray(SFb_CSVL_error15, SFb_CSVL_temp15,7);
     fillArray(SFb_CSVM_error15, SFb_CSVM_temp15,7);
     fillArray(SFb_CSVT_error15, SFb_CSVT_temp15,7);
@@ -87,9 +87,9 @@ float BtagHardcodedConditions::getDiscriminant(const std::string & op){
     else if( op == "JPM")   return 0.545;
     else if( op == "JPT")   return 0.79;
     else if( op == "TCHPT") return 3.41;
-    else if( op == "CSVL")  return 0.605; //0.423;
-    else if( op == "CSVM")  return 0.890; //0.814;
-    else if( op == "CSVT")  return 0.970; //0.941;
+    else if( op == "CSVL")  return 0.460; //0.605; //0.423;
+    else if( op == "CSVM")  return 0.800; //0.890; //0.814;
+    else if( op == "CSVT")  return 0.935; //0.970; //0.941;
     throw cms::Exception("InvalidInput") << "Unknown operating point: "<< op << std::endl;
 }
 
@@ -165,13 +165,16 @@ double BtagHardcodedConditions::GetBtagScaleFactor(double pt, double eta,
     
 }
 
-// 2015 scale factors from csv file in https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation74X50ns
+// 2015 scale factors from csv file in https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation76X
 double BtagHardcodedConditions::GetBtagScaleFactor2015(double pt, double eta,
 						       std::string tagger){
+  if(pt > 670) pt = 670;
+  else if(pt < 30) pt = 30;
+
     double SFb=0;
-    if( tagger=="CSVL")  SFb = 0.908299+(2.70877e-06*(log(pt+370.144)*(log(pt+370.144)*(3-(-(104.614*log(pt+370.144)))))));
-    else if( tagger=="CSVM")  SFb = -(0.0443172)+(0.00496634*(log(pt+1267.85)*(log(pt+1267.85)*(3-(-(0.110428*log(pt+1267.85)))))));
-    else if( tagger=="CSVT")  SFb = -(5.1345)+(0.000820101*(log(pt+11518.1)*(log(pt+11518.1)*(3-(-(8.66128*log(pt+11518.1)))))));
+    if( tagger=="CSVL")  SFb = 0.97149*((1.+(-(5.85053e-05*pt)))/(1.+(-(0.000132479*pt))));
+    else if( tagger=="CSVM")  SFb = 0.934588*((1.+(0.00678184*pt))/(1.+(0.00627144*pt)));
+    else if( tagger=="CSVT")  SFb = 0.886376*((1.+(0.00250226*pt))/(1.+(0.00193725*pt)));
     return SFb;
 }
 
@@ -246,7 +249,6 @@ double BtagHardcodedConditions::GetBtagSFUncertainty2012(double pt, double eta,
     return err;
 }
 
-// 2015 scale factors from csv file in https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation74X50ns
 double BtagHardcodedConditions::GetBtagSFUncertainty2015(double pt, double eta,
                                                          std::string tagger)
 {
@@ -424,10 +426,9 @@ double BtagHardcodedConditions::GetMistagScaleFactor(double pt, double eta,
   } else if (year==2011) {
     return GetMistagSF2011(pt, eta, tagger, "mean");
   } else if (year==2015) {
-    if(tagger == "CSVL") return ((1.07278+(0.000535714*pt))+(-1.14886e-06*(pt*pt)))+(7.0636e-10*(pt*(pt*pt)));
-    else if(tagger == "CSVM") return 1.14022;
-    else if(tagger == "CSVT") return 0.907317;
-    else return 0;
+    // 2015 scale factors from csv file in https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation76X
+    if(tagger == "CSVT") return 0.992339;
+    else return GetMistagSF2015(pt,eta,tagger,"mean");
   } else {
     return 0;
   }
@@ -442,11 +443,8 @@ double BtagHardcodedConditions::GetMistagSFUncertDown(double pt, double eta,
     return (pt>670?2.0:1.0) *
       (GetMistagSF2011(pt, eta, tagger, "mean")- GetMistagSF2011(pt, eta, tagger, "min"));
   } else if (year==2015) {
-    // 2015 scale factors from csv file in https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation74X50ns
-    if(tagger == "CSVL") return (pt>1000 ? 2.0 : 1.0) * (((1.07278+(0.000535714*pt))+(-1.14886e-06*(pt*pt)))+(7.0636e-10*(pt*(pt*pt))) - ((1.01637+(0.000265653*pt))+(-4.22531e-07*(pt*pt)))+(2.23396e-10*(pt*(pt*pt))));
-    else if(tagger == "CSVM") return (pt>1000 ? 2.0 : 1.0) * (1.14022-0.94022);
-    else if(tagger == "CSVT") return (pt>1000 ? 2.0 : 1.0) * (0.907317-0.557317);
-    else return 0;
+    if(tagger == "CSVT") return (pt>1000 ? 2.0 : 1.0) * (0.992339-0.810103);
+    else return (pt>1000 ? 2.0 : 1.0) * (GetMistagSF2015(pt,eta,tagger,"mean") - GetMistagSF2015(pt,eta,tagger,"min"));
   } else {
     return 0;
   }
@@ -461,14 +459,78 @@ double BtagHardcodedConditions::GetMistagSFUncertUp(double pt, double eta,
     return (pt>670?2.0:1.0) *
       (GetMistagSF2011(pt, eta, tagger, "max")- GetMistagSF2011(pt, eta, tagger, "mean"));
   } else if (year==2015) {
-    if(tagger == "CSVL") return (pt>1000 ? 2.0 : 1.0) * (((1.07278+(0.000535714*pt))+(-1.14886e-06*(pt*pt)))+(7.0636e-10*(pt*(pt*pt))) + ((1.12921+(0.000804962*pt))+(-1.87332e-06*(pt*pt)))+(1.18864e-09*(pt*(pt*pt))));
-    else if(tagger == "CSVM") return (pt>1000 ? 2.0 : 1.0) * (1.34022-1.14022);
-    else if(tagger == "CSVT") return (pt>1000 ? 2.0 : 1.0) * (1.257317-0.907317);
-    else return 0;
+    if(tagger == "CSVT") return (pt>1000 ? 2.0 : 1.0) * (1.17457-0.992339);
+    else return (pt>1000 ? 2.0 : 1.0) * (GetMistagSF2015(pt,eta,tagger,"max") - GetMistagSF2015(pt,eta,tagger,"mean"));
   } else {
     return 0;
   }
 }
+
+double BtagHardcodedConditions::GetMistagSF2015(double pt, double eta,
+                                                std::string tagger, std::string meanminmax)
+{
+  
+  double _absEta = abs(eta);
+  double sf = -1;
+  if( tagger=="CSVL" ){
+    if(_absEta < 0.3) {
+      if( meanminmax == "mean" ) sf = ((1.13199+(0.00121087*pt))+(-2.1714e-06*(pt*pt)))+(1.06583e-09*(pt*(pt*pt)));
+      else if( meanminmax == "min" ) sf = ((1.09518+(0.000823444*pt))+(-1.1289e-06*(pt*pt)))+(3.82933e-10*(pt*(pt*pt))); 
+      else if( meanminmax == "max" ) sf = ((1.1688+(0.00159691*pt))+(-3.21137e-06*(pt*pt)))+(1.74795e-09*(pt*(pt*pt)));
+    }
+    else if(_absEta<0.6) {
+      if( meanminmax == "mean" ) sf = ((1.09165+(0.000702517*pt))+(-1.02871e-06*(pt*pt)))+(4.30424e-10*(pt*(pt*pt))) ;
+      else if( meanminmax == "min" ) sf = ((1.05683+(0.000364968*pt))+(-1.36739e-07*(pt*pt)))+(-1.49029e-10*(pt*(pt*pt))) ;
+      else if( meanminmax == "max" ) sf = ((1.12646+(0.00103951*pt))+(-1.91997e-06*(pt*pt)))+(1.00985e-09*(pt*(pt*pt))) ;
+    }
+    else if(_absEta<0.9) {
+      if( meanminmax == "mean" ) sf =  ((1.0784+(0.000436514*pt))+(-4.80533e-07*(pt*pt)))+(1.33671e-10*(pt*(pt*pt))) ;
+      else if( meanminmax == "min" ) sf = ((1.04698+(9.25694e-05*pt))+(4.4349e-07*(pt*pt)))+(-4.79468e-10*(pt*(pt*pt))) ;
+      else if( meanminmax == "max" ) sf = ((1.10982+(0.000780264*pt))+(-1.40461e-06*(pt*pt)))+(7.47048e-10*(pt*(pt*pt))) ;
+    }
+    else if(_absEta<1.2) {
+      if( meanminmax == "mean" ) sf = ((1.07503+(0.000526042*pt))+(-6.49158e-07*(pt*pt)))+(1.62348e-10*(pt*(pt*pt))) ;
+      else if( meanminmax == "min" ) sf = ((1.04579+(0.000173093*pt))+(3.18263e-07*(pt*pt)))+(-4.91223e-10*(pt*(pt*pt))) ;
+      else if( meanminmax == "max" ) sf = ((1.10426+(0.000878747*pt))+(-1.61676e-06*(pt*pt)))+(8.16318e-10*(pt*(pt*pt))) ;
+    }
+    else if(_absEta<1.5) {
+      if( meanminmax == "mean" ) sf = ((1.04288+(0.000657559*pt))+(-1.06594e-06*(pt*pt)))+(3.86717e-10*(pt*(pt*pt))) ;
+      else if( meanminmax == "min" ) sf = ((1.01419+(0.000577889*pt))+(-8.55682e-07*(pt*pt)))+(2.468e-10*(pt*(pt*pt))) ;
+      else if( meanminmax == "max" ) sf = ((1.07156+(0.00073673*pt))+(-1.27588e-06*(pt*pt)))+(5.26892e-10*(pt*(pt*pt))) ;
+    }
+    else if(_absEta<1.8) {
+      if( meanminmax == "mean" ) sf = ((1.03033+(0.000622107*pt))+(-1.09864e-06*(pt*pt)))+(4.7558e-10*(pt*(pt*pt))) ;
+      else if( meanminmax == "min" ) sf = ((1.00339+(0.000508366*pt))+(-7.81139e-07*(pt*pt)))+(2.53078e-10*(pt*(pt*pt))) ;
+      else if( meanminmax == "max" ) sf = ((1.05727+(0.00073532*pt))+(-1.4156e-06*(pt*pt)))+(6.98246e-10*(pt*(pt*pt))) ;
+    }
+    else if(_absEta<2.4) {
+      if( meanminmax == "mean" ) sf = ((1.00087+(0.000789414*pt))+(-1.51105e-06*(pt*pt)))+(8.63264e-10*(pt*(pt*pt))) ;
+      else if( meanminmax == "min" ) sf = ((0.976332+(0.000678258*pt))+(-1.19056e-06*(pt*pt)))+(6.19232e-10*(pt*(pt*pt))) ;
+      else if( meanminmax == "max" ) sf = ((1.02541+(0.000899915*pt))+(-1.83065e-06*(pt*pt)))+(1.10768e-09*(pt*(pt*pt))) ;
+    }
+  }
+  else if( tagger=="CSVM" ){
+    if(_absEta<0.8) {
+      if( meanminmax == "mean" ) sf = ((0.994351+(0.000250077*pt))+(9.24801e-07*(pt*pt)))+(-8.73293e-10*(pt*(pt*pt))) ;
+      else if( meanminmax == "min" ) sf = ((0.949401+(-0.000356232*pt))+(2.24887e-06*(pt*pt)))+(-1.66011e-09*(pt*(pt*pt))) ;
+      else if( meanminmax == "max" ) sf = ((1.03928+(0.000857422*pt))+(-4.02756e-07*(pt*pt)))+(-8.45836e-11*(pt*(pt*pt))) ;
+    }
+    else if(_absEta<1.6) {
+      if( meanminmax == "mean" ) sf = ((1.00939+(0.000461283*pt))+(-6.30306e-07*(pt*pt)))+(3.53075e-10*(pt*(pt*pt))) ;
+      else if( meanminmax == "min" ) sf = ((0.964857+(-2.19898e-05*pt))+(4.74117e-07*(pt*pt)))+(-3.36548e-10*(pt*(pt*pt))) ;
+      else if( meanminmax == "max" ) sf = ((1.05392+(0.000944135*pt))+(-1.73386e-06*(pt*pt)))+(1.04242e-09*(pt*(pt*pt))) ;
+    }
+    else if(_absEta<2.4) {
+      if( meanminmax == "mean" ) sf = ((0.955798+(0.00146058*pt))+(-3.76689e-06*(pt*pt)))+(2.39196e-09*(pt*(pt*pt))) ;
+      else if( meanminmax == "min" ) sf = ((0.910086+(0.00116371*pt))+(-3.02747e-06*(pt*pt)))+(1.86906e-09*(pt*(pt*pt))) ;
+      else if( meanminmax == "max" ) sf = ((1.00151+(0.00175547*pt))+(-4.50251e-06*(pt*pt)))+(2.91473e-09*(pt*(pt*pt))) ;
+    }
+  }
+
+  return sf;
+
+}
+
 
 double BtagHardcodedConditions::GetMistagSF2011(double pt, double eta,
                                                 std::string tagger, std::string meanminmax)

--- a/src/singleLepCalc.cc
+++ b/src/singleLepCalc.cc
@@ -192,6 +192,7 @@ int singleLepCalc::BeginJob()
 int singleLepCalc::AnalyzeEvent(edm::EventBase const & event, BaseEventSelector * selector)
 {     // ----- Get objects from the selector -----
     std::vector<edm::Ptr<pat::Jet> >            const & vSelJets = selector->GetSelectedJets();
+    std::vector<pat::Jet>                       const & vSelCorrJets = selector->GetSelectedCorrJets();
     std::vector<edm::Ptr<pat::Jet> >            const & vSelBtagJets = selector->GetSelectedBtagJets();
     std::vector<edm::Ptr<pat::Jet> >            const & vAllJets = selector->GetAllJets();
     std::vector<std::pair<TLorentzVector,bool>> const & vCorrBtagJets = selector->GetCorrJetsWithBTags();
@@ -222,6 +223,7 @@ int singleLepCalc::AnalyzeEvent(edm::EventBase const & event, BaseEventSelector 
     int _nCorrBtagJets   = (int)vCorrBtagJets.size();
     int _nSelMuons       = (int)vSelMuons.size();
     int _nSelElectrons   = (int)vSelElectrons.size();
+
     edm::Handle<std::vector<reco::Vertex> > pvHandle;
     event.getByLabel(pvCollection_it, pvHandle);
     goodPVs = *(pvHandle.product());
@@ -810,28 +812,35 @@ int singleLepCalc::AnalyzeEvent(edm::EventBase const & event, BaseEventSelector 
     std::vector <double> AK4JetEnergy;
 
     std::vector <int>    AK4JetBTag;
+    std::vector <int>    AK4JetBTag_bSFup;
+    std::vector <int>    AK4JetBTag_bSFdn;
+    std::vector <int>    AK4JetBTag_lSFup;
+    std::vector <int>    AK4JetBTag_lSFdn;
     std::vector <double> AK4JetBDisc;
     std::vector <int>    AK4JetFlav;
 
     //std::vector <double> AK4JetRCN;   
     double AK4HT =.0;
-    for (unsigned int ii = 0; ii < vCorrBtagJets.size(); ii++){
+    for (std::vector<pat::Jet>::const_iterator ii = vSelCorrJets.begin(); ii != vSelCorrJets.end(); ii++){
+      int index = (int)(ii-vSelCorrJets.begin());
 
-        //Four std::vector
-        TLorentzVector lv = vCorrBtagJets[ii].first;
+      AK4JetPt     . push_back(ii->pt());
+      AK4JetEta    . push_back(ii->eta());
+      AK4JetPhi    . push_back(ii->phi());
+      AK4JetEnergy . push_back(ii->energy());
 
-        AK4JetPt     . push_back(lv.Pt());
-        AK4JetEta    . push_back(lv.Eta());
-        AK4JetPhi    . push_back(lv.Phi());
-        AK4JetEnergy . push_back(lv.Energy());
-        
-        AK4JetBTag   . push_back(vCorrBtagJets[ii].second);
-        //AK4JetRCN    . push_back(((*ijet)->chargedEmEnergy()+(*ijet)->chargedHadronEnergy()) / ((*ijet)->neutralEmEnergy()+(*ijet)->neutralHadronEnergy()));
-        AK4JetBDisc  . push_back(vSelJets[ii]->bDiscriminator( "pfCombinedInclusiveSecondaryVertexV2BJetTags" ));
-        AK4JetFlav   . push_back(abs(vSelJets[ii]->hadronFlavour()));
- 
-        //HT
-        AK4HT += lv.Pt(); 
+      AK4JetBTag   . push_back(vCorrBtagJets[index].second);
+      AK4JetBTag_bSFup.push_back(selector->isJetTagged(*ii, event, true, 1));
+      AK4JetBTag_bSFdn.push_back(selector->isJetTagged(*ii, event, true, 2));
+      AK4JetBTag_lSFup.push_back(selector->isJetTagged(*ii, event, true, 3));
+      AK4JetBTag_lSFdn.push_back(selector->isJetTagged(*ii, event, true, 4));
+
+      //AK4JetRCN    . push_back(((*ijet)->chargedEmEnergy()+(*ijet)->chargedHadronEnergy()) / ((*ijet)->neutralEmEnergy()+(*ijet)->neutralHadronEnergy()));
+      AK4JetBDisc  . push_back(ii->bDiscriminator( "pfCombinedInclusiveSecondaryVertexV2BJetTags" ));
+      AK4JetFlav   . push_back(abs(ii->hadronFlavour()));
+
+      //HT
+      AK4HT += ii->pt(); 
     }
     
     //Four std::vector
@@ -841,6 +850,10 @@ int singleLepCalc::AnalyzeEvent(edm::EventBase const & event, BaseEventSelector 
     SetValue("AK4JetEnergy" , AK4JetEnergy);
     SetValue("AK4HT"        , AK4HT);
     SetValue("AK4JetBTag"   , AK4JetBTag);
+    SetValue("AK4JetBTag_bSFup"   , AK4JetBTag_bSFup);
+    SetValue("AK4JetBTag_bSFdn"   , AK4JetBTag_bSFdn);
+    SetValue("AK4JetBTag_lSFup"   , AK4JetBTag_lSFup);
+    SetValue("AK4JetBTag_lSFdn"   , AK4JetBTag_lSFdn);
     //SetValue("AK4JetRCN"    , AK4JetRCN);
     SetValue("AK4JetBDisc"  , AK4JetBDisc);
     SetValue("AK4JetFlav"   , AK4JetFlav);

--- a/src/singleLepEventSelector.cc
+++ b/src/singleLepEventSelector.cc
@@ -559,7 +559,6 @@ bool singleLepEventSelector::operator()( edm::EventBase const & event, pat::strb
                 mvSelPVs.push_back(edm::Ptr<reco::Vertex>(h_primVtx, _n_pvs));
                 ++_n_pvs;
             }
-          
         } // end of PV cuts
 
 
@@ -998,6 +997,7 @@ bool singleLepEventSelector::operator()( edm::EventBase const & event, pat::strb
         mvSelJets.clear();
         mvAllJets.clear();
         mvCorrJetsWithBTags.clear();
+	mvSelCorrJets.clear();
         mvSelBtagJets.clear();
 
         // try to get earlier produced data (in a calc)
@@ -1016,6 +1016,7 @@ bool singleLepEventSelector::operator()( edm::EventBase const & event, pat::strb
 	    TLorentzVector jetP4;
 
 	    pat::Jet tmpJet = _ijet->correctedJet(0);
+	    pat::Jet corrJet = *_ijet;
 
 	    if ( mbPar["doLepJetCleaning"] ){
 		if (mbPar["debug"]) std::cout << "Checking Overlap" << std::endl;
@@ -1044,6 +1045,7 @@ bool singleLepEventSelector::operator()( edm::EventBase const & event, pat::strb
 				    tmpJet.setP4( tmpJet.p4() - muDaughters[muI]->p4() );
 				    if (mbPar["debug"]) std::cout << "  Cleaned Jet : pT = " << tmpJet.pt() << " eta = " << tmpJet.eta() << " phi = " << tmpJet.phi() << std::endl;
 				    jetP4 = correctJet(tmpJet, event, false, true);
+				    corrJet = correctJetReturnPatJet(tmpJet, event, false, true);
 				    if (mbPar["debug"]) std::cout << "Corrected Jet : pT = " << jetP4.Pt() << " eta = " << jetP4.Eta() << " phi = " << jetP4.Phi() << std::endl;
 			            _cleaned = true;
                                     muDaughters.erase( muDaughters.begin()+muI );
@@ -1096,6 +1098,7 @@ bool singleLepEventSelector::operator()( edm::EventBase const & event, pat::strb
 				    tmpJet.setP4( tmpJet.p4() - elDaughters[elI]->p4() );
 				    if (mbPar["debug"]) std::cout << "  Cleaned Jet : pT = " << tmpJet.pt() << " eta = " << tmpJet.eta() << " phi = " << tmpJet.phi() << std::endl;
 				    jetP4 = correctJet(tmpJet, event, false, true);
+				    corrJet = correctJetReturnPatJet(tmpJet, event, false, true);
 				    if (mbPar["debug"]) std::cout << "Corrected Jet : pT = " << jetP4.Pt() << " eta = " << jetP4.Eta() << " phi = " << jetP4.Phi() << std::endl;
 			            _cleaned = true;
                                     elDaughters.erase( elDaughters.begin()+elI );
@@ -1121,6 +1124,7 @@ bool singleLepEventSelector::operator()( edm::EventBase const & event, pat::strb
 	    }
 	    if (!_cleaned) {
                 jetP4 = correctJet(*_ijet, event);
+		corrJet = correctJetReturnPatJet(*_ijet, event);
             }
 
             _isTagged = isJetTagged(*_ijet, event);
@@ -1154,6 +1158,7 @@ bool singleLepEventSelector::operator()( edm::EventBase const & event, pat::strb
                 // save all the good jets
                 ++_n_good_jets;
                 mvSelJets.push_back(edm::Ptr<pat::Jet>( mhJets, _n_jets)); 
+		mvSelCorrJets.push_back(corrJet);
                 mvCorrJetsWithBTags.push_back(jetwithtag);
 
                 if (jetP4.Pt() > _leading_jet_pt) _leading_jet_pt = jetP4.Pt();                         


### PR DESCRIPTION
Open PR -- not going to merge immediately

-- Creates a new vector called mvSelCorrJets which is filled (see singleLepEventSelector) with pat::Jets after lepton cleaning and JEC/JER correction. This allows us to pass cleaned+corrected jets and access all jet methods from the same object.
-- Allows for b tagging shifts all in one LJMet run, saved independently (see singleLepCalc)
-- Decorrelate b SF and light SF uncertainties, access from standard parameters or a function flag
-- Update tagging SFs and uncertainties to 76X values
