### PR TITLE
PF Loose edits/additions; cleaning options

### DIFF
--- a/src/singleLepCalc.cc
+++ b/src/singleLepCalc.cc
@@ -785,7 +785,25 @@ int singleLepCalc::AnalyzeEvent(edm::EventBase const & event, BaseEventSelector 
     //   std::vector <double> AK8JetRCN;       
     for (std::vector<pat::Jet>::const_iterator ijet = AK8Jets->begin(); ijet != AK8Jets->end(); ijet++){
 
+	// PF Loose
+	bool looseJetID = false;
+	pat::Jet rawJet = ijet->correctedJet(0);
+	if(abs(rawJet.eta()) <= 3.0){
+	  looseJetID = (rawJet.neutralHadronEnergyFraction() < 0.99 && 
+			rawJet.neutralEmEnergyFraction() < 0.99 && 
+			(rawJet.chargedMultiplicity()+rawJet.neutralMultiplicity()) > 0) && 
+	    ((abs(rawJet.eta()) <= 2.4 && 
+	      rawJet.chargedHadronEnergyFraction() > 0 && 
+	      rawJet.chargedEmEnergyFraction() < 0.99 && 
+	      rawJet.chargedMultiplicity() > 0) || 
+	     abs(rawJet.eta()) > 2.4);
+	}else{
+	  looseJetID = rawJet.neutralEmEnergyFraction() < 0.9 && rawJet.neutralMultiplicity() > 10;
+	}
+	if(!looseJetID) continue;	
+
         TLorentzVector lvak8 = selector->correctJet(*ijet, event,true);
+
         //Four std::vector
         AK8JetPt     . push_back(lvak8.Pt());
         AK8JetEta    . push_back(lvak8.Eta());


### PR DESCRIPTION
JetSubCalc: cleanup, use corrected pat::Jet only since it now has uncertainties/smearing, add PF Loose requirement for AK8 jets

singleLepCalc: add PF Loose requirement for AK8 jets (could be made an option if that's preferred)

singleLepEventSelector:  add option parameters for lepton-jet cleaning (default to current settings). Current jet selector does not have the newer special requirements for |eta| > 3.0, added them here. 
