### PR TITLE
Apply extra W tagging uncertainties in JetSubCalc

### DIFF
--- a/python/JetSubCalc_cfi.py
+++ b/python/JetSubCalc_cfi.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
-
+import os
 # available bDiscrimiant:
 # - combinedInclusiveSecondaryVertexV2BJetTags
 # - combinedMVABJetTags
@@ -10,6 +10,8 @@ import FWCore.ParameterSet.Config as cms
 # - trackCountingHighPurBJetTags
 # - trackCountingHighEffBJetTags
 # - simpleSecondaryVertexHighPurBJetTags
+
+relBase = os.environ['CMSSW_BASE']
 
 JetSubCalc = cms.PSet(
                       slimmedJetColl     = cms.InputTag("slimmedJets"),
@@ -26,12 +28,16 @@ JetSubCalc = cms.PSet(
                       isMc = cms.bool(True),
                       JECup = cms.bool(False),
                       JECdown = cms.bool(False),
-                      MCL2JetParAK8 = cms.string('/uscms_data/d3/jmanagan/CMSSW_7_4_14/src/LJMet/Com/data/Summer15_25nsV2_MC_L2Relative_AK8PFchs.txt'),
-                      MCL3JetParAK8 = cms.string('/uscms_data/d3/jmanagan/CMSSW_7_4_14/src/LJMet/Com/data/Summer15_25nsV2_MC_L3Absolute_AK8PFchs.txt'),
-                      DataL2JetParAK8 = cms.string('/uscms_data/d3/jmanagan/CMSSW_7_4_14/src/LJMet/Com/data/Summer15_25nsV5_DATA_L2Relative_AK8PFchs.txt'),
-                      DataL3JetParAK8 = cms.string('/uscms_data/d3/jmanagan/CMSSW_7_4_14/src/LJMet/Com/data/Summer15_25nsV5_DATA_L3Absolute_AK8PFchs.txt'),
-                      DataResJetParAK8 = cms.string('/uscms_data/d3/jmanagan/CMSSW_7_4_14/src/LJMet/Com/data/Summer15_25nsV5_DATA_L2L3Residual_AK8PFchs.txt'),
-                      UncertaintyAK8 = cms.string('/uscms_data/d3/jmanagan/CMSSW_7_4_14/src/LJMet/Com/data/Summer15_25nsV7_DATA_Uncertainty_AK8PFchs.txt')           
+                      JERup = cms.bool(False),
+                      JERdown = cms.bool(False),
+                      MCL2JetParAK8 = cms.string(relBase+'/src/LJMet/Com/data/Spring16_25nsV6_MC_L2Relative_AK8PFchs.txt'),
+                      MCL3JetParAK8 = cms.string(relBase+'/src/LJMet/Com/data/Spring16_25nsV6_MC_L3Absolute_AK8PFchs.txt'),
+                      MCPTResAK8 = cms.string(relBase+'/src/LJMet/Com/data/Spring16_25nsV6_MC_PtResolution_AK8PFchs.txt'),
+                      MCSF = cms.string(relBase+'/src/LJMet/Com/data/Spring16_25nsV6_MC_SF_AK4PFchs.txt'),
+                      DataL2JetParAK8 = cms.string(relBase+'/src/LJMet/Com/data/Spring16_25nsV6_DATA_L2Relative_AK8PFchs.txt'),
+                      DataL3JetParAK8 = cms.string(relBase+'/src/LJMet/Com/data/Spring16_25nsV6_DATA_L3Absolute_AK8PFchs.txt'),
+                      DataResJetParAK8 = cms.string(relBase+'/src/LJMet/Com/data/Spring16_25nsV6_DATA_L2L3Residual_AK8PFchs.txt'),
+                      UncertaintyAK8 = cms.string(relBase+'/src/LJMet/Com/data/Spring16_25nsV6_DATA_Uncertainty_AK8PFchs.txt')           
                       )
 
 #######################################################################

--- a/python/singleLepExample_cfg.py
+++ b/python/singleLepExample_cfg.py
@@ -50,8 +50,12 @@ process.JetSubCalc.useL2L3Mass = cms.bool(True)
 process.JetSubCalc.isMc = cms.bool(condorIsMC)
 process.JetSubCalc.JECup = cms.bool(False)
 process.JetSubCalc.JECdown = cms.bool(False)
+process.JetSubCalc.JERup = cms.bool(False)
+process.JetSubCalc.JERdown = cms.bool(False)
 process.JetSubCalc.MCL2JetParAK8 = cms.string(relBase+'/src/LJMet/Com/data/Spring16_25nsV6_MC_L2Relative_AK8PFchs.txt')
 process.JetSubCalc.MCL3JetParAK8 = cms.string(relBase+'/src/LJMet/Com/data/Spring16_25nsV6_MC_L3Absolute_AK8PFchs.txt')
+process.JetSubCalc.MCPTResAK8 = cms.string(relBase+'/src/LJMet/Com/data/Spring16_25nsV6_MC_PtResolution_AK8PFchs.txt')
+process.JetSubCalc.MCSF = cms.string(relBase+'/src/LJMet/Com/data/Spring16_25nsV6_MC_SF_AK4PFchs.txt')
 process.JetSubCalc.DataL2JetParAK8 = cms.string(relBase+'/src/LJMet/Com/data/Spring16_25nsV6_DATA_L2Relative_AK8PFchs.txt')
 process.JetSubCalc.DataL3JetParAK8 = cms.string(relBase+'/src/LJMet/Com/data/Spring16_25nsV6_DATA_L3Absolute_AK8PFchs.txt')
 process.JetSubCalc.DataL2L3JetParAK8 = cms.string(relBase+'/src/LJMet/Com/data/Spring16_25nsV6_DATA_L2L3Residual_AK8PFchs.txt')
@@ -75,7 +79,7 @@ process.event_selector = cms.PSet(
     
     # Trigger cuts
     trigger_cut  = cms.bool(True),
-    dump_trigger = cms.bool(True),
+    dump_trigger = cms.bool(False),
 
     trigger_path_el = cms.vstring(
         'HLT_Ele27_eta2p1_WPLoose_Gsf_v1', 
@@ -110,11 +114,11 @@ process.event_selector = cms.PSet(
     
     # Jet cuts
     jet_cuts                 = cms.bool(True),
-    jet_minpt                = cms.double(30.0),
+    jet_minpt                = cms.double(0.0),
     jet_maxeta               = cms.double(5.0),
     min_jet                  = cms.int32(2),
     max_jet                  = cms.int32(4000),
-    leading_jet_pt           = cms.double(30.0),
+    leading_jet_pt           = cms.double(0.0),
 
     # muon cuts
     muon_cuts                = cms.bool(True),
@@ -238,11 +242,12 @@ process.event_selector = cms.PSet(
 #
 
 process.inputs = cms.PSet (
-    nEvents    = cms.int32(5000),
+    nEvents    = cms.int32(1000),
     skipEvents = cms.int32(0),
     lumisToProcess = CfgTypes.untracked(CfgTypes.VLuminosityBlockRange()),
     fileNames  = cms.vstring(
        'root://eoscms.cern.ch//store/mc/RunIISpring16MiniAODv2/TprimeTprime_M-800_TuneCUETP8M1_13TeV-madgraph-pythia8/MINIAODSIM/PUSpring16RAWAODSIM_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/70000/0424F3F9-B425-E611-B483-02163E0135B1.root',
+       #'testTprimeMiniAOD.root',
         )
     )
 


### PR DESCRIPTION
W tagging recommendations mass scaling/smearing are now tied to the central JEC and JER uncertainties. Adding a branch to calculate and apply them here. See the python file for extra text files to pass.
