### PR TITLE
Update PF Loose, W tag uncerts, MVA param name

### DIFF
--- a/src/BaseEventSelector.cc
+++ b/src/BaseEventSelector.cc
@@ -158,7 +158,7 @@ void BaseEventSelector::BeginJob(std::map<std::string, edm::ParameterSet const >
                 mvsPar["ElMVAweightFiles"].push_back("../weights/EIDmva_EE_10_oldNonTrigSpring15_ConvVarCwoBoolean_TMVA412_FullStatLowPt_PairNegWeightsGlobal_BDT.weights.xml");
             }
             if ( par[_key].exists("ElMVAweightFiles_alt") )
-                mvsPar["ElMVAweightFiles_alt"] = par[_key].getParameter<std::vector<std::string> >("ElMVAweightFiles");
+                mvsPar["ElMVAweightFiles_alt"] = par[_key].getParameter<std::vector<std::string> >("ElMVAweightFiles_alt");
             if (mvsPar["ElMVAweightFiles_alt"].size()!=3) {
                 mvsPar["ElMVAweightFiles_alt"].clear();
                 mvsPar["ElMVAweightFiles_alt"].push_back("../weights/electronID_mva_Spring16_GeneralPurpose_V1_EB1_10.weights.xml");

--- a/src/JetSubCalc.cc
+++ b/src/JetSubCalc.cc
@@ -407,6 +407,7 @@ int JetSubCalc::AnalyzeEvent(edm::EventBase const & event, BaseEventSelector * s
     // Pruned, trimmed and filtered masses available
     std::vector<double> theJetAK8PrunedMass;
     std::vector<double> theJetAK8PrunedMassWtagUncerts;
+    std::vector<double> theJetAK8SoftDropMassWtagUncerts;
     std::vector<double> theJetAK8SoftDropMass;
     
     // n-subjettiness variables tau1, tau2, and tau3 available
@@ -464,15 +465,17 @@ int JetSubCalc::AnalyzeEvent(edm::EventBase const & event, BaseEventSelector * s
 
       pat::Jet rawJet = ijet->correctedJet(0);
       bool looseJetID = false;
-      if(abs(rawJet.eta()) <= 3.0){
+      if(abs(rawJet.eta()) <= 2.7){
 	looseJetID = (rawJet.neutralHadronEnergyFraction() < 0.99 && 
 		      rawJet.neutralEmEnergyFraction() < 0.99 && 
-		      (rawJet.chargedMultiplicity()+rawJet.neutralMultiplicity()) > 0) && 
+		      (rawJet.chargedMultiplicity()+rawJet.neutralMultiplicity()) > 1) && 
 	  ((abs(rawJet.eta()) <= 2.4 && 
 	    rawJet.chargedHadronEnergyFraction() > 0 && 
 	    rawJet.chargedEmEnergyFraction() < 0.99 && 
 	    rawJet.chargedMultiplicity() > 0) || 
 	   abs(rawJet.eta()) > 2.4);
+      }else if(abs(rawJet.eta()) <= 3.0){
+	looseJetID = rawJet.neutralEmEnergyFraction() > 0.01 && rawJet.neutralHadronEnergyFraction() < 0.98 && rawJet.neutralMultiplicity() > 2;
       }else{
 	looseJetID = rawJet.neutralEmEnergyFraction() < 0.9 && rawJet.neutralMultiplicity() > 10;
       }
@@ -540,9 +543,9 @@ int JetSubCalc::AnalyzeEvent(edm::EventBase const & event, BaseEventSelector * s
 	  Variation JERcentral = Variation::NOMINAL;
 	  Variation JERshifted = Variation::UP;
 	  if(JERdn) JERshifted = Variation::DOWN;	  
-	  // JetWTagging TWiki: 76X JMR for pruned mass + nsubjettiness, resolution scale factor = 1
+	  // JetWTagging TWiki: 80X JMR for pruned mass + nsubjettiness, resolution scale factor = 1.07
 	  // uncertainty is 10.3% within eta 2.5, JER #oplus 10.3% outside
-	  double factor_pruned = 0.0;
+	  double factor_pruned = 0.07;
 	  double uncert = fabs(resolution_SF.getScaleFactor(parameters,JERcentral) - resolution_SF.getScaleFactor(parameters,JERshifted));
 	  double uncert_pruned = 0.103;
 	  if(fabs(l2l3jet.eta()) > 2.5) uncert_pruned = sqrt(uncert*uncert + 0.103*0.103);
@@ -635,6 +638,7 @@ int JetSubCalc::AnalyzeEvent(edm::EventBase const & event, BaseEventSelector * s
       theJetAK8PrunedMass  .push_back(thePrunedMass);
       theJetAK8SoftDropMass.push_back(theSoftDropMass);
       theJetAK8PrunedMassWtagUncerts.push_back(thePrunedMass*ptscale_pruned*unc_pruned/unc);
+      theJetAK8SoftDropMassWtagUncerts.push_back(theSoftDropMass*ptscale_pruned*unc_pruned/unc);
       
       theJetAK8NjettinessTau1.push_back(theNjettinessTau1);
       theJetAK8NjettinessTau2.push_back(theNjettinessTau2);
@@ -749,6 +753,7 @@ int JetSubCalc::AnalyzeEvent(edm::EventBase const & event, BaseEventSelector * s
 
     SetValue("theJetAK8PrunedMass",   theJetAK8PrunedMass);
     SetValue("theJetAK8PrunedMassWtagUncerts",   theJetAK8PrunedMassWtagUncerts);
+    SetValue("theJetAK8SoftDropMassWtagUncerts",   theJetAK8SoftDropMassWtagUncerts);
     SetValue("theJetAK8SoftDropMass", theJetAK8SoftDropMass);
     
     SetValue("theJetAK8NjettinessTau1", theJetAK8NjettinessTau1);

--- a/src/singleLepCalc.cc
+++ b/src/singleLepCalc.cc
@@ -890,14 +890,14 @@ int singleLepCalc::AnalyzeEvent(edm::EventBase const & event, BaseEventSelector 
 	if(abs(rawJet.eta()) <= 2.7){
 	  looseJetID = (rawJet.neutralHadronEnergyFraction() < 0.99 && 
 			rawJet.neutralEmEnergyFraction() < 0.99 && 
-			(rawJet.chargedMultiplicity()+rawJet.neutralMultiplicity()) > 0) && 
+			(rawJet.chargedMultiplicity()+rawJet.neutralMultiplicity()) > 1) && 
 	    ((abs(rawJet.eta()) <= 2.4 && 
 	      rawJet.chargedHadronEnergyFraction() > 0 && 
 	      rawJet.chargedEmEnergyFraction() < 0.99 && 
 	      rawJet.chargedMultiplicity() > 0) || 
 	     abs(rawJet.eta()) > 2.4);
 	}else if(abs(rawJet.eta()) <= 3.0){
-	  looseJetID = rawJet.neutralEmEnergyFraction() < 0.9 && rawJet.neutralMultiplicity() > 2;
+	  looseJetID = rawJet.neutralEmEnergyFraction() > 0.01 && rawJet.neutralHadronEnergyFraction() < 0.98 && rawJet.neutralMultiplicity() > 2;
 	}else{
 	  looseJetID = rawJet.neutralEmEnergyFraction() < 0.9 && rawJet.neutralMultiplicity() > 10;
 	}

--- a/src/singleLepEventSelector.cc
+++ b/src/singleLepEventSelector.cc
@@ -1213,12 +1213,18 @@ bool singleLepEventSelector::operator()( edm::EventBase const & event, pat::strb
 
 	        // quality cuts
 	        if (fabs(_ijet->correctedJet(0).eta()) < 2.7 && (*jetSel_)( *_ijet, retJet ) ){ } 
-	        else if (fabs(_ijet->correctedJet(0).eta()) >= 2.7 && fabs(_ijet->correctedJet(0).eta()) < 3.0 &&
-			 (_ijet->correctedJet(0).neutralEmEnergyFraction() < 0.9 || _ijet->correctedJet(0).neutralMultiplicity() > 2)){ }
-	        else if (fabs(_ijet->correctedJet(0).eta()) >= 3.0 && 
-			 (_ijet->correctedJet(0).neutralEmEnergyFraction() < 0.9 || _ijet->correctedJet(0).neutralMultiplicity() > 10)){ }
+	        else if (fabs(_ijet->correctedJet(0).eta()) >= 2.7 && 
+			 fabs(_ijet->correctedJet(0).eta()) < 3.0 && 
+			 _ijet->correctedJet(0).neutralEmEnergyFraction() > 0.01 && 
+			 _ijet->correctedJet(0).neutralHadronEnergyFraction() < 0.98 &&
+			 _ijet->correctedJet(0).neutralMultiplicity() > 2
+			 ){ }
+		else if (fabs(_ijet->correctedJet(0).eta()) >= 3.0 && 
+			 _ijet->correctedJet(0).neutralEmEnergyFraction() < 0.9 && 
+			 _ijet->correctedJet(0).neutralMultiplicity() > 10
+			 ){ }
 	        else break; // fail 
-	
+
                 _passpf = true;
 
                 if ( jetP4.Pt() > mdPar["jet_minpt"] ){ }


### PR DESCRIPTION
1. Updates to PF loose: 1 correction to |eta| < 2.4, new recommendation for |eta| 2.7 -- 3.0 

2. Updated to 80X W tag smearing

3. Fixed electron MVA weight file parameter name